### PR TITLE
Chore: Change of variable name executor to avatar

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,10 +1,5 @@
 module.exports = {
-  skipFiles: [
-    "test/TestToken",
-    "test/TestExecutor",
-    "IModule.sol",
-    "IModuleManager.sol",
-  ],
+  skipFiles: ["test/TestToken", "test/TestAvatar"],
   mocha: {
     grep: "@skip-on-coverage", // Find everything with this tag
     invert: true, // Run the grep's inverse set.

--- a/contracts/ExitModule.sol
+++ b/contracts/ExitModule.sol
@@ -54,7 +54,7 @@ contract Exit is Module {
         __Ownable_init();
         transferOwnership(_owner);
 
-        emit SafeExitModuleSetup(msg.sender, _avatar);
+        emit ExitModuleSetup(msg.sender, _avatar);
     }
 
     /// @dev Execute the share of assets and the transfer of designated tokens

--- a/contracts/ExitModule.sol
+++ b/contracts/ExitModule.sol
@@ -13,24 +13,24 @@ contract Exit is Module {
     event SafeExitModuleSetup(address indexed initiator, address indexed safe);
     event ExitSuccessful(address indexed leaver);
 
-    /// @notice Mapping of denied tokens defined by the executor
+    /// @notice Mapping of denied tokens defined by the avatar
     mapping(address => bool) public deniedTokens;
 
     /// @dev Initialize function, will be triggered when a new proxy is deployed
     /// @param _owner Address of the owner
-    /// @param _executor Address of the executor (e.g. a Safe or Delay Module)
+    /// @param _avatar Address of the avatar (e.g. a Safe or Delay Module)
     /// @param _designatedToken Address of the ERC20 token that will define the share of users
     /// @param _circulatingSupply Circulating Supply of designated token
     /// @notice Designated token address can not be zero
     constructor(
         address _owner,
-        address _executor,
+        address _avatar,
         address _designatedToken,
         address _circulatingSupply
     ) {
         bytes memory initParams = abi.encode(
             _owner,
-            _executor,
+            _avatar,
             _designatedToken,
             _circulatingSupply
         );
@@ -40,21 +40,21 @@ contract Exit is Module {
     function setUp(bytes memory initParams) public override {
         (
             address _owner,
-            address _executor,
+            address _avatar,
             address _designatedToken,
             address _circulatingSupply
         ) = abi.decode(initParams, (address, address, address, address));
         require(!initialized, "Module is already initialized");
         initialized = true;
-        require(_executor != address(0), "Executor can not be zero address");
-        avatar = _executor;
+        require(_avatar != address(0), "Avatar can not be zero address");
+        avatar = _avatar;
         designatedToken = ERC20(_designatedToken);
         circulatingSupply = CirculatingSupply(_circulatingSupply);
 
         __Ownable_init();
         transferOwnership(_owner);
 
-        emit SafeExitModuleSetup(msg.sender, _executor);
+        emit SafeExitModuleSetup(msg.sender, _avatar);
     }
 
     /// @dev Execute the share of assets and the transfer of designated tokens
@@ -88,7 +88,7 @@ contract Exit is Module {
         emit ExitSuccessful(msg.sender);
     }
 
-    /// @dev Execute a token transfer through the executor
+    /// @dev Execute a token transfer through the avatar
     /// @param token address of token to transfer
     /// @param leaver address that will receive the transfer
     function transferToken(

--- a/contracts/test/TestAvatar.sol
+++ b/contracts/test/TestAvatar.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.8.0;
 
-contract TestExecutor {
+contract TestAvatar {
     address public module;
 
     error NotAuthorized(address unacceptedAddress);

--- a/docs/setup_guide.md
+++ b/docs/setup_guide.md
@@ -23,7 +23,7 @@ Note 2: If you want to test the exit function (the how-to is described below) - 
 The first step is to deploy the module. Every Safe will have their own module. The module is linked to a Safe (called owner in the contract).
 
 - The owner is the address that can call setter functions (would usually be the safe)
-- The executor is the address that the module uses to execute transactions (it calls the `execTransactionFromModule` function)
+- The avatar is the address that the module uses to execute transactions (it calls the `execTransactionFromModule` function)
 
 ## Deploying the module
 
@@ -32,17 +32,17 @@ Hardhat tasks can be used to deploy a Exit module instance. There are two differ
 These setup tasks requires the following parameters:
 
 - `owner` (the address of the owner)
-- `executor` (the address of the executor - e.g. Safe)
+- `avatar` (the address of the avatar - e.g. Safe)
 - `token` (the address of the designated token)
 - `supply` (circulating supply of designated token, if not provided 10e18 will be set)
 
 An example for this on rinkeby would be:
 
-`yarn hardhat --network rinkeby setup --owner <owner_address> --executor <executor_address> --token 0x0000000000000000000000000000000000000100 --supply <circulating_supply>`
+`yarn hardhat --network rinkeby setup --owner <owner_address> --avatar <avatar_address> --token 0x0000000000000000000000000000000000000100 --supply <circulating_supply>`
 
 or
 
-`yarn hardhat --network rinkeby factorySetup --factory <factory_address> --mastercopy <masterCopy_address> --owner <owner_address> --executor <executor_address> --token 0x0000000000000000000000000000000000000100 --supply <circulating_supply>`
+`yarn hardhat --network rinkeby factorySetup --factory <factory_address> --mastercopy <masterCopy_address> --owner <owner_address> --avatar <avatar_address> --token 0x0000000000000000000000000000000000000100 --supply <circulating_supply>`
 
 This should return the address of the deployed Exit module. For this guide we assume this to be `0x9797979797979797979797979797979797979797`
 
@@ -51,7 +51,7 @@ Once the module is deployed you should verify the source code (Note: If you used
 Please note that this supply argument must be the address of the deployed Circulating Supply contract that was deployed on the setup scripts. Check the setup script logs in order to get the address
 
 An example for this on Rinkeby would be:
-`yarn hardhat --network rinkeby verifyEtherscan --module 0x9797979797979797979797979797979797979797 --owner <owner_address> --executor <executor_address> --token 0x0000000000000000000000000000000000000100 --supply <circulating_supply_contract_address>`
+`yarn hardhat --network rinkeby verifyEtherscan --module 0x9797979797979797979797979797979797979797 --owner <owner_address> --avatar <avatar_address> --token 0x0000000000000000000000000000000000000100 --supply <circulating_supply_contract_address>`
 
 ## Enabling the module
 

--- a/src/tasks/setup.ts
+++ b/src/tasks/setup.ts
@@ -9,8 +9,8 @@ const AddressOne = "0x0000000000000000000000000000000000000001";
 task("setup", "deploy a Exit Module")
   .addParam("owner", "Address of the owner", undefined, types.string)
   .addParam(
-    "executor",
-    "Address of the executor (e.g. Safe)",
+    "avatar",
+    "Address of the avatar (e.g. Safe)",
     undefined,
     types.string
   )
@@ -33,7 +33,7 @@ task("setup", "deploy a Exit Module")
     const supply = await Supply.deploy(taskArgs.supply);
     const module = await Module.deploy(
       taskArgs.owner,
-      taskArgs.executor,
+      taskArgs.avatar,
       taskArgs.token,
       supply.address
     );
@@ -52,8 +52,8 @@ task("factorySetup", "Deploy and initialize Safe Exit through a Proxy Factory")
   )
   .addParam("owner", "Address of the owner", undefined, types.string)
   .addParam(
-    "executor",
-    "Address of the executor (e.g. Safe)",
+    "avatar",
+    "Address of the avatar (e.g. Safe)",
     undefined,
     types.string
   )
@@ -84,7 +84,7 @@ task("factorySetup", "Deploy and initialize Safe Exit through a Proxy Factory")
 
     const encodedData = new AbiCoder().encode(
       ["address", "address", "address", "address"],
-      [taskArgs.owner, taskArgs.executor, taskArgs.token, supply.address]
+      [taskArgs.owner, taskArgs.avatar, taskArgs.token, supply.address]
     );
 
     const Module = await hardhatRuntime.ethers.getContractFactory("Exit");
@@ -105,8 +105,8 @@ task("verifyEtherscan", "Verifies the contract on etherscan")
   .addParam("module", "Address of the Safe Exit", undefined, types.string)
   .addParam("owner", "Address of the owner", undefined, types.string)
   .addParam(
-    "executor",
-    "Address of the executor (e.g. Safe)",
+    "avatar",
+    "Address of the avatar (e.g. Safe)",
     undefined,
     types.string
   )
@@ -122,7 +122,7 @@ task("verifyEtherscan", "Verifies the contract on etherscan")
       address: taskArgs.module,
       constructorArgsParams: [
         taskArgs.owner,
-        taskArgs.executor,
+        taskArgs.avatar,
         taskArgs.token,
         taskArgs.supply,
       ],

--- a/test/ExitModule.spec.ts
+++ b/test/ExitModule.spec.ts
@@ -76,7 +76,6 @@ describe("Exit", async () => {
   });
 
   describe("setUp() ", () => {
-
     it("throws if module has already been initialized", async () => {
       const { designatedToken, circulatingSupply } = await baseSetup();
       const Module = await hre.ethers.getContractFactory("Exit");
@@ -105,8 +104,7 @@ describe("Exit", async () => {
     });
 
     it("should emit event because of successful set up", async () => {
-      const { designatedToken, avatar, circulatingSupply } =
-        await baseSetup();
+      const { designatedToken, avatar, circulatingSupply } = await baseSetup();
       const Module = await hre.ethers.getContractFactory("Exit");
       const module = await Module.deploy(
         avatar.address,
@@ -118,10 +116,8 @@ describe("Exit", async () => {
       await module.deployed();
 
       await expect(module.deployTransaction)
-      chore/executor-to-avatar
-        .to.emit(module, "SafeExitModuleSetup")
+        .to.emit(module, "ExitModuleSetup")
         .withArgs(user.address, avatar.address);
-
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -617,7 +617,7 @@
 
 "@gnosis/zodiac@github:gnosis/zodiac#master":
   version "0.0.0"
-  resolved "https://codeload.github.com/gnosis/zodiac/tar.gz/37e7aae683e8ed971c27c35f4486e6c7688275f3"
+  resolved "https://codeload.github.com/gnosis/zodiac/tar.gz/30dce26b46150166769bdf55bc2d5ad0eeabe5de"
   dependencies:
     "@gnosis.pm/mock-contract" "^4.0.0"
     "@gnosis.pm/safe-contracts" "1.3.0"
@@ -862,9 +862,9 @@
     web3 "1.5.2"
 
 "@truffle/provider@^0.2.24":
-  version "0.2.38"
-  resolved "https://registry.yarnpkg.com/@truffle/provider/-/provider-0.2.38.tgz#7a55a9083cdc6b896d40ac0c547ef3acdfcb0d92"
-  integrity sha512-YKdTUST+G741jFtwgwSpXA0sni5ClLPfhLVUirLxKAiLXI3HnYDl1TAtf/THTPWGMmfd3ygfkXVlxceYuSNuRQ==
+  version "0.2.39"
+  resolved "https://registry.yarnpkg.com/@truffle/provider/-/provider-0.2.39.tgz#5a544e734fa5c41c28cacae88e139ed13d5c9ead"
+  integrity sha512-svL1u/BtPyteZbYnngxVBvYHkesTRLFYXdklDJT2S+X4jy8dmHRZIUdM6SL4SOrDPICiEnnp1fczsVWEqrEdig==
   dependencies:
     "@truffle/error" "^0.0.14"
     "@truffle/interface-adapter" "^0.5.5"
@@ -2781,9 +2781,9 @@ copy-descriptor@^0.1.0:
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
 core-js-pure@^3.0.1:
-  version "3.16.4"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.16.4.tgz#8b23122628d88c560f209812b9b2d9ebbce5e29c"
-  integrity sha512-bY1K3/1Jy9D8Jd12eoeVahNXHLfHFb4TXWI8SQ4y8bImR9qDPmGITBAfmcffTkgUvbJn87r8dILOTWW5kZzkgA==
+  version "3.17.2"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.17.2.tgz#ba6311b6aa1e2f2adeba4ac6ec51a9ff40bdc1af"
+  integrity sha512-2VV7DlIbooyTI7Bh+yzOOWL9tGwLnQKHno7qATE+fqZzDKYr6llVjVQOzpD/QLZFgXDPb8T71pJokHEZHEYJhQ==
 
 core-js@^2.4.0, core-js@^2.5.0:
   version "2.6.12"
@@ -3177,9 +3177,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.47:
-  version "1.3.825"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.825.tgz#5d361eeaaf591bb2ce06cfeff86354b429d662b8"
-  integrity sha512-BO3FfWVeH8GQ0DBbi4HCL09OPgvN+0goqWlgKOCmCXcnrlgL5GA69nb7ZyjpWgpFUacBftg8BrXU2WLOSuHAxQ==
+  version "1.3.829"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.829.tgz#efd360b594824fcd84e24c6eb0c8e41e2a44fbc7"
+  integrity sha512-5EXDbvsaLRxS1UOfRr8Hymp3dR42bvBNPgzVuPwUFj3v66bpvDUcNwwUywQUQYn/scz26/3Sgd3fNVGQOlVwvQ==
 
 elliptic@6.5.4, elliptic@^6.4.0, elliptic@^6.5.2, elliptic@^6.5.3:
   version "6.5.4"
@@ -4465,9 +4465,9 @@ fmix@^0.1.0:
     imul "^1.0.0"
 
 follow-redirects@^1.10.0, follow-redirects@^1.12.1:
-  version "1.14.2"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.2.tgz#cecb825047c00f5e66b142f90fed4f515dec789b"
-  integrity sha512-yLR6WaE2lbF0x4K2qE2p9PEXKLDjUjnR/xmjS3wHAYxtlsI9MLLBJUZirAHKzUZDGLxje7w/cXR49WOUo4rbsA==
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.3.tgz#6ada78118d8d24caee595595accdc0ac6abd022e"
+  integrity sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw==
 
 for-each@^0.3.3, for-each@~0.3.3:
   version "0.3.3"
@@ -6330,11 +6330,9 @@ match-all@^1.2.6:
   integrity sha512-0EESkXiTkWzrQQntBu2uzKvLu6vVkUGz40nGPbSZuegcfE5UuSzNjLaIu76zJWuaT/2I3Z/8M06OlUOZLGwLlQ==
 
 mcl-wasm@^0.7.1:
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/mcl-wasm/-/mcl-wasm-0.7.8.tgz#4d0dc5a92f7bd20892fd3fcd41764acf86fd1e6e"
-  integrity sha512-qNHlYO6wuEtSoH5A8TcZfCEHtw8gGPqF6hLZpQn2SVd/Mck0ELIKOkmj072D98S9B9CI/jZybTUC96q1P2/ZDw==
-  dependencies:
-    typescript "^4.3.4"
+  version "0.7.9"
+  resolved "https://registry.yarnpkg.com/mcl-wasm/-/mcl-wasm-0.7.9.tgz#c1588ce90042a8700c3b60e40efb339fc07ab87f"
+  integrity sha512-iJIUcQWA88IJB/5L15GnJVnSQJmf/YaxxV6zRavv83HILHaJQb6y0iFyDMdDO0gN8X37tdxmAOrH/P8B6RB8sQ==
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -9080,11 +9078,6 @@ typescript@4.3.5:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
   integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
-
-typescript@^4.3.4:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
-  integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
 
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Changes proposed on this proposal:
- `Executor` name has been changed to `Avatar` in tests, documentation, setup scripts, and contracts
- `TestExecutor` file changed to `TestAvatar`